### PR TITLE
Return a boolean instead of throwing error if unable to drop element.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,10 +36,11 @@ const DragSimulator = {
     }
     if (!this.dropped) {
       return this.drop().then(() => {
-        throw new Error(`Exceeded maximum tries of: ${this.MAX_TRIES}, aborting`);
+        console.error(`Exceeded maximum tries of: ${this.MAX_TRIES}, aborting`);
+        return false;
       });
     }
-    return this.drop();
+    return this.drop().then(() => true);
   },
   init(source, target, position) {
     this.source = source;


### PR DESCRIPTION
In my test, I would like to test that a certain element can NOT be dropped somewhere (because it is not allowed to). If this expected drop-error returns a boolean instead of throwing an error, I can assert this in my test.