### PR TITLE
Reset the counter on init.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ const DragSimulator = {
     this.source = source;
     this.target = target;
     this.position = position;
+    this.counter = 0;
 
     this.dragstart();
 


### PR DESCRIPTION
Reset the counter to prevent drop failure after drag'n'dropping many things.