### PR TITLE
Detect detached elements during drag'n'drop

### DIFF
--- a/src/examples/Detach.vue
+++ b/src/examples/Detach.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="row">
+    <draggable v-model="left" class="column" data-testid="left" group="items">
+      <div v-for="item in left" :key="item.id" class="item" :data-testid="`item-${item.id}`">{{ item.id }}</div>
+    </draggable>
+    <draggable
+      v-if="!detached"
+      v-model="right"
+      class="column"
+      data-testid="right"
+      group="items"
+      @drop.native="detached = true"
+    >
+      <div v-for="item in right" :key="item.id" class="item" :data-testid="`item-${item.id}`">{{ item.id }}</div>
+    </draggable>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Detach',
+  data() {
+    return {
+      detached: false,
+      left: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
+      right: [],
+    }
+  },
+}
+</script>

--- a/tests/specs/detach.spec.js
+++ b/tests/specs/detach.spec.js
@@ -1,0 +1,9 @@
+describe('Drag drop', () => {
+  it('should not throw error when element is detached on drop', () => {
+    cy.visit('/')
+
+    cy.setExample('Detach')
+
+    cy.findByTestId('item-1').drag('[data-testid="right"]')
+  })
+})


### PR DESCRIPTION
The drop event is split up in `drop`, `mouseup` and `pointerup` events.
When the target receives a `drop` event, is may be detached from the
DOM. So check if the elements is still in the DOM before proceeding the
further events in the drop chain.

Closes #14 