### PR TITLE
While dragging, trigger mousemove in addition to dragover

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ const DragSimulator = {
           position: this.position,
           force: this.force,
         })
+        .trigger('mousemove', this.position)
         .wait(this.DELAY_INTERVAL_MS)
         .then(() => this.dragover())
     }


### PR DESCRIPTION
Certain applications only listen to mousedown/move/up instead of the
drag events. For those applications to work with this cypress command,
this library needs to also trigger the mousemove event while dragging.