### PR TITLE
Use specific event constructors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,29 +28,61 @@ const DragSimulator = {
   dragstart({ clientX, clientY } = {}) {
     return cy
       .wrap(this.source)
-      .trigger('pointerdown', { which: 1, button: 0, force: this.force, clientX, clientY, position: this.position })
-      .trigger('mousedown', { which: 1, button: 0, force: this.force, clientX, clientY, position: this.position })
-      .trigger('dragstart', { dataTransfer, force: this.force, position: this.position })
+      .trigger('pointerdown', {
+        which: 1,
+        button: 0,
+        force: this.force,
+        clientX,
+        clientY,
+        position: this.position,
+        eventConstructor: 'PointerEvent',
+      })
+      .trigger('mousedown', {
+        which: 1,
+        button: 0,
+        force: this.force,
+        clientX,
+        clientY,
+        position: this.position,
+        eventConstructor: 'MouseEvent',
+      })
+      .trigger('dragstart', { dataTransfer, force: this.force, position: this.position, eventConstructor: 'DragEvent' })
   },
   drop({ clientX, clientY } = {}) {
-    return this.target.trigger('drop', { dataTransfer, force: this.force, position: this.position }).then(() => {
-      if (isAttached(this.targetElement)) {
-        this.target
-          .trigger('mouseup', { which: 1, button: 0, force: this.force, clientX, clientY, position: this.position })
-          .then(() => {
-            if (isAttached(this.targetElement)) {
-              this.target.trigger('pointerup', {
-                which: 1,
-                button: 0,
-                force: this.force,
-                clientX,
-                clientY,
-                position: this.position,
-              })
-            }
-          })
-      }
-    })
+    return this.target
+      .trigger('drop', {
+        dataTransfer,
+        force: this.force,
+        position: this.position,
+        eventConstructor: 'DragEvent',
+      })
+      .then(() => {
+        if (isAttached(this.targetElement)) {
+          this.target
+            .trigger('mouseup', {
+              which: 1,
+              button: 0,
+              force: this.force,
+              clientX,
+              clientY,
+              position: this.position,
+              eventConstructor: 'MouseEvent',
+            })
+            .then(() => {
+              if (isAttached(this.targetElement)) {
+                this.target.trigger('pointerup', {
+                  which: 1,
+                  button: 0,
+                  force: this.force,
+                  clientX,
+                  clientY,
+                  position: this.position,
+                  eventConstructor: 'PointerEvent',
+                })
+              }
+            })
+        }
+      })
   },
   dragover({ clientX, clientY } = {}) {
     if (!this.dropped && this.hasTriesLeft) {
@@ -60,18 +92,21 @@ const DragSimulator = {
           dataTransfer,
           position: this.position,
           force: this.force,
+          eventConstructor: 'DragEvent',
         })
         .trigger('mousemove', {
           force: this.force,
           position: this.position,
           clientX,
           clientY,
+          eventConstructor: 'MouseEvent',
         })
         .trigger('pointermove', {
           force: this.force,
           position: this.position,
           clientX,
           clientY,
+          eventConstructor: 'PointerEvent',
         })
         .wait(this.DELAY_INTERVAL_MS)
         .then(() => this.dragover({ clientX, clientY }))


### PR DESCRIPTION
This pull requests explicitly sets the eventConstructor parameter when cy.trigger() is called.

This makes the events generated by cypress-drag-drop resemble the events the browser generates more closely, which can fixes bugs like taye/interact.js#871, and can make cypress-drag-drop a solution for cypress-io/cypress#6161.