### PR TITLE
Always trigger dragover

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const DragSimulator = {
     })
   },
   dragover({ clientX, clientY } = {}) {
-    if (!this.dropped && this.hasTriesLeft) {
+    if (!this.counter || !this.dropped && this.hasTriesLeft) {
       this.counter += 1
       return this.target
         .trigger('dragover', {


### PR DESCRIPTION
I had a test which was failing b/c my component seemed to have resized from starting to be dragged, even without actually having been dragged.
This simple change just ensures that the `dragover` method is run at least once, seeing as drag-and-drop would require the actual drag to happen.

This closes #48 