### PR TITLE
Added hoverTime option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Force the drag'n'drop interaction. Meaning that the grabbing, moving and droppin
 is forced. See https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Forcing
 for more information.
 
+# hoverTime
+
+A delay in milliseconds between moving the cursor to the target and dropping.
+
 ## other options
 
 You can also use other options defined by default by Cypress, like: `ctrlKey`, `log`, `timeout`...

--- a/index.js
+++ b/index.js
@@ -121,11 +121,14 @@ const DragSimulator = {
     })
   },
   drag(sourceWrapper, targetSelector, options) {
-    this.init(sourceWrapper, targetSelector, options)
+    const action = this.init(sourceWrapper, targetSelector, options)
       .then(() => this.dragstart())
-      .then(() => this.dragover())
-      .then(() => this.drop())
-      .then(() => true)
+      .then(() => this.dragover());
+    if (options && options.hoverTime && (options.hoverTime > 0)) {
+      action.then(() => cy.wait(options.hoverTime));
+    }
+    action.then(() => this.drop())
+      .then(() => true);
   },
   move(sourceWrapper, options) {
     const { x: deltaX, y: deltaY } = options


### PR DESCRIPTION
For when you want to hover over the target for a while before dropping.

Example use case would be moving a file in a tree to a folder and hover over it for a while to expand it.