### PR TITLE
Explicit where to put options in the move command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ describe('Dragtest', () => {
 The `move` command is a child command.
 The command only accepts elements.
 Define `x` and `y` as an object parameter to move the element in x- and y-position relative to the elements current position.
-The command also accepts all the [common options](#options).
 
 In your cypress spec use the command as follows:
 
@@ -77,6 +76,18 @@ describe('Dragtest', () => {
     cy.visit('/yourpage')
 
     cy.get('.sourceitem').move({ x: 100, y: 100 })
+  })
+})
+```
+
+The command also accepts all the [common options](#options).
+
+```javascript
+describe('Dragtest', () => {
+  it('should dragndrop', () => {
+    cy.visit('/yourpage')
+
+    cy.get('.sourceitem').move({ x: 100, y: 100, ...options })
   })
 })
 ```


### PR DESCRIPTION
It took me a while to figure out that for `move`, options had to be passed in the 2nd argument alongside with `x` and `y` rather than in a 3rd argument like in `drag`.

This PR adds an example to the Readme in order to explicit how options should be provided.