### PR TITLE
In move, drop the element at the final pointer location

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,10 +130,11 @@ const DragSimulator = {
   move(sourceWrapper, options) {
     const { x: deltaX, y: deltaY } = options
     const { top, left } = sourceWrapper.offset()
+    const finalCoords = { clientX: top + deltaX, clientY: left + deltaY };
     this.init(sourceWrapper, sourceWrapper, options)
       .then(() => this.dragstart({ clientX: top, clientY: left }))
-      .then(() => this.dragover({ clientX: top + deltaX, clientY: left + deltaY }))
-      .then(() => this.drop())
+      .then(() => this.dragover(finalCoords))
+      .then(() => this.drop(finalCoords))
   },
 }
 

--- a/src/examples/MoveOnMouseUp.vue
+++ b/src/examples/MoveOnMouseUp.vue
@@ -1,0 +1,61 @@
+<template>
+  <div
+    class="item absolute"
+    :style="position"
+    data-testid="draggable"
+    @mousedown="handleMouseDown"
+    @mouseup="handleMouseUp"
+  ></div>
+</template>
+
+<script>
+export default {
+  name: 'Move',
+  data() {
+    return {
+      isMouseDown: false,
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+    }
+  },
+  computed: {
+    position() {
+      return `transform: translate(${this.top}px, ${this.left}px)`
+    },
+  },
+  methods: {
+    handleMouseDown(e) {
+      e.preventDefault()
+      this.isMouseDown = true
+      this.x = e.clientX
+      this.y = e.clientY
+    },
+    handleMouseUp(e) {
+      if (!this.isMouseDown) {
+        return
+      }
+      e.preventDefault()
+      const deltaX = this.x - e.clientX
+      const deltaY = this.y - e.clientY
+      this.x = e.clientX
+      this.y = e.clientY
+      this.top = this.top - deltaX
+      this.left = this.left - deltaY
+      this.isMouseDown = false
+    },
+  },
+}
+</script>
+
+<style>
+.absolute {
+  position: absolute;
+  margin: 0;
+  top: 100px;
+  left: 100px;
+  width: 1000px;
+  height: 1000px;
+}
+</style>

--- a/tests/specs/move.spec.js
+++ b/tests/specs/move.spec.js
@@ -19,4 +19,25 @@ describe('Drag drop', () => {
       expect(left).to.be.equal(200)
     })
   })
+
+  it('should trigger mouseup at the final mouse location', () => {
+    cy.visit('/')
+
+    cy.setExample('MoveOnMouseUp')
+
+    cy.findByTestId('draggable').should((target) => {
+      const { top, left } = target.offset()
+      expect(top).to.be.equal(100)
+      expect(left).to.be.equal(100)
+    })
+
+    cy.findByTestId('draggable').move({ x: 100, y: 100, position: 'center' })
+
+    cy.findByTestId('draggable').should('have.css', 'transform', 'matrix(1, 0, 0, 1, 100, 100)')
+    cy.findByTestId('draggable').should((target) => {
+      const { top, left } = target.offset()
+      expect(top).to.be.equal(200)
+      expect(left).to.be.equal(200)
+    })
+  })
 })


### PR DESCRIPTION
I had issues using this library with a drag-and-drop component where we use the `clientX` attribute of the `pointerup` event.

In the current codebase, the `pointerup` event is always triggered with a `clientX` of  `0`. This change suggestion would trigger this event at the final location of the pointer.

