### PR TITLE
Allow unequal options for source and target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- It's possible to apply different options to either the drag source or the drop target.
+- BREAKING: Default position for the event trigger is in the element's center.
+
 ## [1.8.1] - 2021-09-01
 
 - Introduce Changelog

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cypress-drag-drop
 
-A cypress child command for drag'n'drop support.
+A Cypress child command for drag'n'drop support.
 
 # Setup
 
@@ -28,10 +28,10 @@ Or, if you are using ES module syntax:
 import '@4tw/cypress-drag-drop'
 ```
 
-This will register the `drag` command.
+This will register the `drag` and `move` command.
 
 
-If you're using TypeScript, the following configuration in a `tsconfig.json`
+If you're using TypeScript, put the following configuration in a `tsconfig.json`
 
 ```json
 {
@@ -47,9 +47,9 @@ If you're using TypeScript, the following configuration in a `tsconfig.json`
 
 The `drag` command is a child command.
 The command only accepts elements.
-As the drop target simply pass a selector as string.
+As the drop target simply pass a selector as a string.
 
-In your cypress spec use the command as follows:
+In your Cypress spec use the command as follows:
 
 ```javascript
 describe('Dragtest', () => {
@@ -61,7 +61,7 @@ describe('Dragtest', () => {
 })
 ```
 
-The command also accepts all the [common options](#options).
+Pass the options as an object in the second paramteter.
 
 ```javascript
 describe('Dragtest', () => {
@@ -73,60 +73,49 @@ describe('Dragtest', () => {
 })
 ```
 
+During the drag and drop interaction, two elements are involved. The source element being dragged and the drop target.
+In order to decide what options should either be applied to the source or the target, the options object can be divided in `source` and `target`. Options that are not specific to the source or target are applied to both the source and the target.
+
+``` javascript
+cy.get('.sourceitem').drag('.target', {
+  source: { x: 100, y: 100 }, // applies to the element being dragged
+  target: { position: 'left' }, // applies to the drop target
+  force: true, // applied to both the source and target element
+})
+```
+
+The options are directly passed to Cypress' `trigger` command.
+So, all options from https://docs.cypress.io/api/commands/trigger#Arguments are possible.
+
 ## move
 
 The `move` command is a child command.
 The command only accepts elements.
-Define `x` and `y` as an object parameter to move the element in x- and y-position relative to the elements current position.
+Define `deltaX` and `deltaY` as an object parameter to move the element in x- and y-position relative to the element's current position.
 
-In your cypress spec use the command as follows:
+In your Cypress spec use the command as follows:
 
 ```javascript
-describe('Dragtest', () => {
-  it('should dragndrop', () => {
+describe('Movetest', () => {
+  it('should move', () => {
     cy.visit('/yourpage')
 
-    cy.get('.sourceitem').move({ x: 100, y: 100 })
+    cy.get('.sourceitem').move({ deltaX: 100, deltaY: 100 })
   })
 })
 ```
 
-The command also accepts all the [common options](#options).
+The command accepts all options from https://docs.cypress.io/api/commands/trigger#Arguments except `position`, `x` and `y` because they have no effect, since the command makes use of `clientX` and `clientY` internally.
 
 ```javascript
-describe('Dragtest', () => {
-  it('should dragndrop', () => {
+describe('Movetest', () => {
+  it('should move', () => {
     cy.visit('/yourpage')
 
-    cy.get('.sourceitem').move({ x: 100, y: 100, ...options })
+    cy.get('.sourceitem').move({ deltaX: 100, deltaY: 100, ...options })
   })
 })
 ```
-
-
-# Options
-
-## position
-
-Decide at which position the element should be grabbed, moved and dropped.
-
-Possible values are topLeft, top, topRight, left, center, right, bottomLeft,
-bottom, and bottomRight.
-
-The default position is `top`.
-
-See https://docs.cypress.io/api/commands/trigger.html#Arguments for more information.
-## force
-
-Force the drag'n'drop interaction. Meaning that the grabbing, moving and dropping
-is forced. See https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Forcing
-for more information.
-
-## other options
-
-You can also use other options defined by default by Cypress, like: `ctrlKey`, `log`, `timeout`...
-
-See https://docs.cypress.io/api/commands/click.html#Arguments for more information.
 
 # Development
 
@@ -134,13 +123,13 @@ The plugin itself is implemented in the `index.js` file.
 
 ## Testing
 
-The tests can be run using cypress:
+The tests can be run using Cypress:
 
 ```
 yarn test
 ```
 
-The test fixtures are under `src/examples/`. Using the `setExample` cypress command
+The test fixtures are under `src/examples/`. Using the `setExample` Cypress command
 the fixture is loaded and ready to run tests on. The first attribute in the `setExample` command
 is the name of the fixture which needs to be the filename of the component.
 
@@ -156,3 +145,7 @@ Release a new version of this package:
 ```
 yarn run release
 ```
+
+# Changelog
+
+Have a look at the [Changelog](CHANGELOG.md)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,14 @@
 /// <reference types="cypress" />
 
 type Options = Partial<Cypress.ClickOptions & {
-  position: Cypress.PositionType
+  source: Cypress.ClickOptions
+  target: Cypress.ClickOptions
 }>
 
-type MoveOptions = Options & {
-  x: number
-  y: number
-}
+type MoveOptions = Partial<Cypress.ClickOptions & {
+  deltaX: number
+  deltaY: number
+}>
 
 declare namespace Cypress {
   interface Chainable {

--- a/tests/specs/basic.spec.js
+++ b/tests/specs/basic.spec.js
@@ -6,7 +6,7 @@ describe('Drag drop', () => {
 
     cy.findByTestId('left').find('.item').assertList(['1', '2', '3', '4', '5', '6'])
 
-    cy.findByTestId('item-1').drag('[data-testid="right"]')
+    cy.findByTestId('item-1').drag('[data-testid="right"]', { target: { position: 'left' } })
 
     cy.findByTestId('right').find('.item').assertList(['1'])
 

--- a/tests/specs/move.spec.js
+++ b/tests/specs/move.spec.js
@@ -10,7 +10,7 @@ describe('Drag drop', () => {
       expect(left).to.be.equal(100)
     })
 
-    cy.findByTestId('draggable').move({ x: 100, y: 100, position: 'center' })
+    cy.findByTestId('draggable').move({ deltaX: 100, deltaY: 100 })
 
     cy.findByTestId('draggable').should('have.css', 'transform', 'matrix(1, 0, 0, 1, 100, 100)')
     cy.findByTestId('draggable').should((target) => {
@@ -31,7 +31,7 @@ describe('Drag drop', () => {
       expect(left).to.be.equal(100)
     })
 
-    cy.findByTestId('draggable').move({ x: 100, y: 100, position: 'center' })
+    cy.findByTestId('draggable').move({ deltaX: 100, deltaY: 100 })
 
     cy.findByTestId('draggable').should('have.css', 'transform', 'matrix(1, 0, 0, 1, 100, 100)')
     cy.findByTestId('draggable').should((target) => {


### PR DESCRIPTION
It is now possible to apply different options to either the drag and drop interaction.