### PR TITLE
Avoid setting "clientX" and "clientY" to "undefined" in drag() call. Fix swapped x/y coordings in move()

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ const DragSimulator = {
     const { top, left } = sourceWrapper.offset()
     const finalCoords = { clientX: top + deltaX, clientY: left + deltaY }
     this.init(sourceWrapper, sourceWrapper, options)
-      .then(() => this.dragstart({ clientX: top, clientY: left }))
+      .then(() => this.dragstart({ clientX: left, clientY: top }))
       .then(() => this.dragover(finalCoords))
       .then(() => this.drop(finalCoords))
   },

--- a/index.js
+++ b/index.js
@@ -35,28 +35,26 @@ const DragSimulator = {
   get target() {
     return cy.wrap(this.targetElement)
   },
-  dragstart({ clientX, clientY } = {}) {
+  dragstart(clientPosition = {}) {
     return cy
       .wrap(this.source)
       .trigger('pointerdown', {
         which: 1,
         button: 0,
-        clientX,
-        clientY,
+        ...clientPosition,
         eventConstructor: 'PointerEvent',
         ...this.options.source,
       })
       .trigger('mousedown', {
         which: 1,
         button: 0,
-        clientX,
-        clientY,
+        ...clientPosition,
         eventConstructor: 'MouseEvent',
         ...this.options.source,
       })
       .trigger('dragstart', { dataTransfer, eventConstructor: 'DragEvent', ...this.options.source })
   },
-  drop({ clientX, clientY } = {}) {
+  drop(clientPosition = {}) {
     return this.target
       .trigger('drop', {
         dataTransfer,
@@ -69,8 +67,7 @@ const DragSimulator = {
             .trigger('mouseup', {
               which: 1,
               button: 0,
-              clientX,
-              clientY,
+              ...clientPosition,
               eventConstructor: 'MouseEvent',
               ...this.options.target,
             })
@@ -79,8 +76,7 @@ const DragSimulator = {
                 this.target.trigger('pointerup', {
                   which: 1,
                   button: 0,
-                  clientX,
-                  clientY,
+                  ...clientPosition,
                   eventConstructor: 'PointerEvent',
                   ...this.options.target,
                 })
@@ -89,7 +85,7 @@ const DragSimulator = {
         }
       })
   },
-  dragover({ clientX, clientY } = {}) {
+  dragover(clientPosition = {}) {
     if (!this.counter || (!this.dropped && this.hasTriesLeft)) {
       this.counter += 1
       return this.target
@@ -100,18 +96,16 @@ const DragSimulator = {
         })
         .trigger('mousemove', {
           ...this.options.target,
-          clientX,
-          clientY,
+          ...clientPosition,
           eventConstructor: 'MouseEvent',
         })
         .trigger('pointermove', {
           ...this.options.target,
-          clientX,
-          clientY,
+          ...clientPosition,
           eventConstructor: 'PointerEvent',
         })
         .wait(this.DELAY_INTERVAL_MS)
-        .then(() => this.dragover({ clientX, clientY }))
+        .then(() => this.dragover(clientPosition))
     }
     if (!this.dropped) {
       console.error(`Exceeded maximum tries of: ${this.MAX_TRIES}, aborting`)


### PR DESCRIPTION
This PR actually addresses two issues:

1) Issue #80 : "top" and "left" are swapped in the call to "dragstart" within "move()"
2) Issue #60 : When we add eventlisteners for that evuluate the "clientX" and "clientY" of the move-events,
    we notice that those values are null. This is probably because they are set to "undefined" in the trigger() call.
    This change makes sure that the properties are not there (rather than being undefined). This means that cypress
    fills in the correct values depending on the elements location.

Please tell me, if you need any changes or additional things for the PR.