### PR TITLE
Extend Options to allow for x/y use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Extend type Options to allow for x/y use
+
 ## [2.2.3] - 2022-12-12
 
 - Add support for Cypress 12.x.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,13 @@
 /// <reference types="cypress" />
 
+type LocationOptions = {
+  x: number
+  y: number
+}
+
 type Options = Partial<Cypress.ClickOptions & {
-  source: Cypress.ClickOptions
-  target: Cypress.ClickOptions
+  source: Cypress.ClickOptions | LocationOptions
+  target: Cypress.ClickOptions | LocationOptions
 }>
 
 type MoveOptions = Partial<Cypress.ClickOptions & {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please provide a general summary of your changes in the Title above. -->

## Description
<!--- Please describe your changes in detail -->
This should fix #103, where x and y are no valid params of the target/source option. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the ``README.md`` accordingly.
- [x] I have added an entry in ``CHANGELOG.md`` in the ``[Unreleased]`` section.
