### PR TITLE
Fix/drag end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5] - 2023-07-07
+
+- Add dragend event trigger to drop function
+
 ## [2.2.4] - 2023-06-01
 
 - Extend type Options to allow for x/y use

--- a/index.js
+++ b/index.js
@@ -80,6 +80,11 @@ const DragSimulator = {
                   eventConstructor: 'PointerEvent',
                   ...this.options.target,
                 })
+                this.target.trigger('dragend', {
+                  dataTransfer,
+                  eventConstructor: 'DragEvent',
+                  ...this.options.target
+                })
               }
             })
         }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please provide a general summary of your changes in the Title above. -->

## Description
Using this plugin would cause failures when a dragend event needs to be happen. I added the dragend trigger after the drop event inside the drop function.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
- [] I have updated the ``README.md`` accordingly.
- [x] I have added an entry in ``CHANGELOG.md`` in the ``[Unreleased]`` section.
